### PR TITLE
fix Oro\..\UserManager

### DIFF
--- a/src/Oro/Bundle/UserBundle/Entity/UserManager.php
+++ b/src/Oro/Bundle/UserBundle/Entity/UserManager.php
@@ -6,6 +6,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\Common\Persistence\ObjectRepository;
 use Doctrine\ORM\QueryBuilder;
 use Pim\Bundle\UserBundle\Entity\UserInterface;
+use Pim\Bundle\UserBundle\Entity\User;
 use Symfony\Component\Security\Core\Encoder\EncoderFactoryInterface;
 use Symfony\Component\Security\Core\Exception\UnsupportedUserException;
 use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;


### PR DESCRIPTION
Add use of Pim\Bundle\UserBundle\Entity\User to UserManager

fix call of User::ROLE_DEFAULT in UserManager::updateUser

When using a third party bundle to manage authentication (FR3DLdap in my case), this method is called by Oro\Bundle\UserBundle\EventListener\LoginSubscriber::onLogin. As the default Oro\Bundle\UserBundle\Entity\User doesn't exist in your repository, the User class isn't recognized.